### PR TITLE
When JVM jobs failing, don't display the Windows one if green

### DIFF
--- a/src/main/java/io/quarkus/bot/workflow/WorkflowConstants.java
+++ b/src/main/java/io/quarkus/bot/workflow/WorkflowConstants.java
@@ -8,4 +8,5 @@ public class WorkflowConstants {
     public static final String QUARKUS_CI_WORKFLOW_NAME = "Quarkus CI";
     public static final String PULL_REQUEST_NUMBER_PREFIX = "pull-request-number-";
     public static final String JVM_TESTS_PREFIX = "JVM Tests - ";
+    public static final String WINDOWS = "Windows";
 }

--- a/src/main/java/io/quarkus/bot/workflow/report/WorkflowReportJob.java
+++ b/src/main/java/io/quarkus/bot/workflow/report/WorkflowReportJob.java
@@ -58,6 +58,10 @@ public class WorkflowReportJob {
         return name.startsWith(WorkflowConstants.JVM_TESTS_PREFIX);
     }
 
+    public boolean isJvmLinux() {
+        return isJvm() && !name.contains(WorkflowConstants.WINDOWS);
+    }
+
     public boolean isFailing() {
         return !Conclusion.SUCCESS.equals(conclusion);
     }

--- a/src/main/resources/templates/WorkflowReportFormatter/checkRunReportSummary.md
+++ b/src/main/resources/templates/WorkflowReportFormatter/checkRunReportSummary.md
@@ -3,7 +3,7 @@
 | Status | Name | Step | Test failures | Logs | Raw logs |
 | :-:  | --  | --  | :-:  | :-:  | :-:  |
 {#for job in report.jobs}
-{#if job.failing || (report.jvmJobsFailing && job.jvm)}
+{#if job.failing || (report.jvmJobsFailing && job.jvmLinux)}
 | {job.conclusionEmoji} | {job.name} | {#if job.failingStep}`{job.failingStep}`{/if} | {#if job.testFailuresAnchor}[Test failures](#user-content-{job.testFailuresAnchor}){#else if job.failing}{#if !job.skipped}:warning: Check →{/if}{/if} | {#if job.url}[Logs]({job.url}){/if} | {#if job.rawLogsUrl}[Raw logs]({job.rawLogsUrl}){/if}
 {/if}
 {/for}

--- a/src/main/resources/templates/WorkflowReportFormatter/commentReport.md
+++ b/src/main/resources/templates/WorkflowReportFormatter/commentReport.md
@@ -5,7 +5,7 @@
 | Status | Name | Step | Test failures | Logs | Raw logs |
 | :-:  | --  | --  | :-:  | :-:  | :-:  |
 {#for job in report.jobs}
-{#if job.failing || (report.jvmJobsFailing && job.jvm)}
+{#if job.failing || (report.jvmJobsFailing && job.jvmLinux)}
 | {job.conclusionEmoji} | {job.name} | {#if job.failingStep}`{job.failingStep}`{/if} | {#if job.testFailuresAnchor && job.testFailures}[Test failures](#user-content-{job.testFailuresAnchor}){#else if job.failing}{#if !job.skipped}:warning: Check →{/if}{/if} | {#if job.url}[Logs]({job.url}){/if} | {#if job.rawLogsUrl}[Raw logs]({job.rawLogsUrl}){/if}
 {/if}
 {/for}


### PR DESCRIPTION
The Windows job runs a limited number of the tests so having it green is
not enough.