### PR TITLE
Remove invalid label when issues or pull requests are reopen

### DIFF
--- a/src/main/java/io/quarkus/bot/RemoveInvalidLabelOnReopenAction.java
+++ b/src/main/java/io/quarkus/bot/RemoveInvalidLabelOnReopenAction.java
@@ -1,0 +1,47 @@
+package io.quarkus.bot;
+
+import io.quarkiverse.githubapp.event.Issue;
+import io.quarkiverse.githubapp.event.PullRequest;
+import io.quarkus.bot.config.QuarkusBotConfig;
+import io.quarkus.bot.util.GHIssues;
+import io.quarkus.bot.util.GHPullRequests;
+import io.quarkus.bot.util.Labels;
+import org.jboss.logging.Logger;
+import org.kohsuke.github.GHEventPayload;
+import org.kohsuke.github.GHIssue;
+import org.kohsuke.github.GHPullRequest;
+
+import javax.inject.Inject;
+import java.io.IOException;
+
+class RemoveInvalidLabelOnReopenAction {
+    private static final Logger LOG = Logger.getLogger(RemoveInvalidLabelOnReopenAction.class);
+
+    @Inject
+    QuarkusBotConfig quarkusBotConfig;
+
+    public void onIssueReopen(@Issue.Reopened GHEventPayload.Issue issuePayload) throws IOException {
+        GHIssue issue = issuePayload.getIssue();
+
+        if (GHIssues.hasLabel(issue, Labels.TRIAGE_INVALID)) {
+            if (!quarkusBotConfig.isDryRun()) {
+                issue.removeLabel(Labels.TRIAGE_INVALID);
+            } else {
+                LOG.info("Issue #" + issue.getNumber() + " - Remove label: " + Labels.TRIAGE_INVALID);
+            }
+        }
+    }
+
+    public void onPullRequestReopen(@PullRequest.Reopened GHEventPayload.PullRequest pullRequestPayload) throws IOException {
+        GHPullRequest pullRequest = pullRequestPayload.getPullRequest();
+
+        if (GHPullRequests.hasLabel(pullRequest, Labels.TRIAGE_INVALID)) {
+            if (!quarkusBotConfig.isDryRun()) {
+                pullRequest.removeLabel(Labels.TRIAGE_INVALID);
+            } else {
+                LOG.info("Pull request #" + pullRequest.getNumber() + " - Remove label: " + Labels.TRIAGE_INVALID);
+            }
+        }
+    }
+
+}

--- a/src/main/java/io/quarkus/bot/util/GHPullRequests.java
+++ b/src/main/java/io/quarkus/bot/util/GHPullRequests.java
@@ -1,0 +1,16 @@
+package io.quarkus.bot.util;
+
+import org.kohsuke.github.GHLabel;
+import org.kohsuke.github.GHPullRequest;
+
+public final class GHPullRequests {
+
+    public static boolean hasLabel(GHPullRequest pullRequest, String labelName) {
+        for (GHLabel label : pullRequest.getLabels()) {
+            if (labelName.equals(label.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
This branch add support removing `triage/invalid` label from issue/pull request when they are reopened. 

I tested it in my playground repo: 
- https://github.com/glefloch/quarkus-bot-playground/pull/3
- https://github.com/glefloch/quarkus-bot-playground/issues/2

close #33