### PR TITLE
Cancel workflow on pull request close action

### DIFF
--- a/src/main/java/io/quarkus/bot/CancelWorkflowOnClosedPullRequest.java
+++ b/src/main/java/io/quarkus/bot/CancelWorkflowOnClosedPullRequest.java
@@ -1,0 +1,49 @@
+package io.quarkus.bot;
+
+import io.quarkiverse.githubapp.event.PullRequest;
+import io.quarkus.bot.config.QuarkusBotConfig;
+import io.quarkus.bot.workflow.WorkflowConstants;
+import org.jboss.logging.Logger;
+import org.kohsuke.github.GHEventPayload;
+import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHWorkflowRun;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+class CancelWorkflowOnClosedPullRequest {
+    private static final Logger LOG = Logger.getLogger(CancelWorkflowOnClosedPullRequest.class);
+
+    @Inject
+    QuarkusBotConfig quarkusBotConfig;
+
+    public void onClose(@PullRequest.Closed GHEventPayload.PullRequest pullRequestPayload) throws IOException {
+
+        GHPullRequest pullRequest = pullRequestPayload.getPullRequest();
+
+        List<GHWorkflowRun> ghWorkflowRuns = pullRequest.getRepository()
+                .queryWorkflowRuns()
+                .branch(pullRequest.getHead().getRef())
+                .list()
+                .toList()
+                .stream()
+                .filter(workflowRun -> workflowRun.getHeadRepository().getOwnerName()
+                        .equals(pullRequest.getHead().getRepository().getOwnerName()))
+                .filter(workflowRun -> WorkflowConstants.QUARKUS_CI_WORKFLOW_NAME.equals(workflowRun.getName()) ||
+                        WorkflowConstants.QUARKUS_DOCUMENTATION_CI_WORKFLOW_NAME.equals(workflowRun.getName()))
+                .filter(workflowRun -> workflowRun.getStatus() == GHWorkflowRun.Status.QUEUED
+                        || workflowRun.getStatus() == GHWorkflowRun.Status.IN_PROGRESS)
+                .collect(Collectors.toList());
+
+        for (GHWorkflowRun workflowRun : ghWorkflowRuns) {
+            if (!quarkusBotConfig.isDryRun()) {
+                workflowRun.cancel();
+            } else {
+                LOG.info("Workflow run #" + workflowRun.getId() + " - Cancelling as pull request #" + pullRequest.getNumber()
+                        + " is now closed");
+            }
+        }
+    }
+}

--- a/src/main/java/io/quarkus/bot/workflow/WorkflowConstants.java
+++ b/src/main/java/io/quarkus/bot/workflow/WorkflowConstants.java
@@ -6,6 +6,7 @@ public class WorkflowConstants {
     public static final String MESSAGE_ID_ACTIVE = "<!-- Quarkus-GitHub-Bot/msg-id:workflow-run-status-active -->";
     public static final String MESSAGE_ID_HIDDEN = "<!-- Quarkus-GitHub-Bot/msg-id:workflow-run-status-hidden -->";
     public static final String QUARKUS_CI_WORKFLOW_NAME = "Quarkus CI";
+    public static final String QUARKUS_DOCUMENTATION_CI_WORKFLOW_NAME = "Quarkus Documentation CI";
     public static final String PULL_REQUEST_NUMBER_PREFIX = "pull-request-number-";
     public static final String JVM_TESTS_PREFIX = "JVM Tests - ";
     public static final String WINDOWS = "Windows";


### PR DESCRIPTION
This branch make sure that running "Quarkus CI" workflow are cancelled when a pull request is closed. 

Unfortunately, the api that list workflow runs does not support `user:branch` notation, I followed your hint @gsmet  and add a verification on branch name and repository owner. 

close #80 