### PR TITLE
Add support for test/retest command in pull request comment

### DIFF
--- a/src/main/java/io/quarkus/bot/PullRequestCommandHandler.java
+++ b/src/main/java/io/quarkus/bot/PullRequestCommandHandler.java
@@ -15,6 +15,7 @@ import org.kohsuke.github.ReactionContent;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -74,7 +75,7 @@ public class PullRequestCommandHandler {
     private Optional<Command<GHPullRequest>> extractCommand(String comment) {
         Matcher matcher = QUARKUS_BOT_MENTION.matcher(comment);
         if (matcher.matches()) {
-            String commandLabel = matcher.group(1);
+            String commandLabel = matcher.group(1).toLowerCase(Locale.ROOT).trim();
             return commands.stream().filter(command -> command.labels().contains(commandLabel)).findFirst();
         }
         return Optional.empty();

--- a/src/main/java/io/quarkus/bot/PullRequestCommandHandler.java
+++ b/src/main/java/io/quarkus/bot/PullRequestCommandHandler.java
@@ -82,7 +82,8 @@ public class PullRequestCommandHandler {
     }
 
     private boolean canRunCommand(GHRepository repository, GHUser user) throws IOException {
-        return repository.getPermission(user) == GHPermissionType.WRITE
-                || repository.getPermission(user) == GHPermissionType.ADMIN;
+        GHPermissionType permission = repository.getPermission(user);
+
+        return permission == GHPermissionType.WRITE || permission == GHPermissionType.ADMIN;
     }
 }

--- a/src/main/java/io/quarkus/bot/PullRequestCommandHandler.java
+++ b/src/main/java/io/quarkus/bot/PullRequestCommandHandler.java
@@ -1,0 +1,79 @@
+package io.quarkus.bot;
+
+import io.quarkiverse.githubapp.event.IssueComment;
+import io.quarkus.bot.command.Command;
+import io.quarkus.bot.config.QuarkusBotConfig;
+import org.jboss.logging.Logger;
+import org.kohsuke.github.GHEventPayload;
+import org.kohsuke.github.GHIssue;
+import org.kohsuke.github.GHPermissionType;
+import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GHUser;
+import org.kohsuke.github.ReactionContent;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class PullRequestCommandHandler {
+
+    private static final Logger LOG = Logger.getLogger(PullRequestCommandHandler.class);
+
+    private static final String QUARKUS_BOT_NAME = "quarkus-bot[bot]";
+    private static final Pattern QUARKUS_BOT_MENTION = Pattern.compile("^@(?:quarkus-?)?bot\\s+([a-z _\\-]+)");
+
+    @Inject
+    Instance<Command<GHPullRequest>> commands;
+
+    @Inject
+    QuarkusBotConfig quarkusBotConfig;
+
+    public void onComment(@IssueComment.Created @IssueComment.Edited GHEventPayload.IssueComment commentPayload)
+            throws IOException {
+        GHUser user = commentPayload.getComment().getUser();
+        GHIssue issue = commentPayload.getIssue();
+        GHRepository repository = commentPayload.getRepository();
+
+        if (QUARKUS_BOT_NAME.equals(commentPayload.getComment().getUserName())) {
+            return;
+        }
+
+        if (issue.isPullRequest()) {
+            Optional<Command<GHPullRequest>> command = extractCommand(commentPayload.getComment().getBody());
+            if (command.isPresent() && canRunCommand(repository, user)) {
+                GHPullRequest pullRequest = repository.getPullRequest(issue.getNumber());
+                ReactionContent reactionResult = command.get().run(pullRequest);
+                postReaction(commentPayload, issue, reactionResult);
+            } else {
+                postReaction(commentPayload, issue, ReactionContent.MINUS_ONE);
+            }
+        }
+    }
+
+    private void postReaction(GHEventPayload.IssueComment comment, GHIssue issue, ReactionContent reactionResult)
+            throws IOException {
+        if (!quarkusBotConfig.isDryRun()) {
+            comment.getComment().createReaction(reactionResult);
+        } else {
+            LOG.info("Pull Request #" + issue.getNumber() + " - Add reaction: " + reactionResult.getContent());
+        }
+    }
+
+    private Optional<Command<GHPullRequest>> extractCommand(String comment) {
+        Matcher matcher = QUARKUS_BOT_MENTION.matcher(comment);
+        if (matcher.matches()) {
+            String commandLabel = matcher.group(1);
+            return commands.stream().filter(command -> command.labels().contains(commandLabel)).findFirst();
+        }
+        return Optional.empty();
+    }
+
+    private boolean canRunCommand(GHRepository repository, GHUser user) throws IOException {
+        return repository.getPermission(user) == GHPermissionType.WRITE
+                || repository.getPermission(user) == GHPermissionType.ADMIN;
+    }
+}

--- a/src/main/java/io/quarkus/bot/command/Command.java
+++ b/src/main/java/io/quarkus/bot/command/Command.java
@@ -1,0 +1,14 @@
+package io.quarkus.bot.command;
+
+import org.kohsuke.github.ReactionContent;
+
+import java.io.IOException;
+import java.util.List;
+
+public interface Command<T> {
+
+    List<String> labels();
+
+    ReactionContent run(T input) throws IOException;
+
+}

--- a/src/main/java/io/quarkus/bot/command/RerunWorkflowCommand.java
+++ b/src/main/java/io/quarkus/bot/command/RerunWorkflowCommand.java
@@ -1,0 +1,65 @@
+package io.quarkus.bot.command;
+
+import io.quarkus.bot.config.QuarkusBotConfig;
+import io.quarkus.bot.workflow.WorkflowConstants;
+import org.jboss.logging.Logger;
+import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GHWorkflowRun;
+import org.kohsuke.github.ReactionContent;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@ApplicationScoped
+public class RerunWorkflowCommand implements Command<GHPullRequest> {
+
+    private static final Logger LOG = Logger.getLogger(RerunWorkflowCommand.class);
+
+    @Inject
+    QuarkusBotConfig quarkusBotConfig;
+
+    @Override
+    public List<String> labels() {
+        return Arrays.asList("test", "retest");
+    }
+
+    @Override
+    public ReactionContent run(GHPullRequest pullRequest) throws IOException {
+        GHRepository repository = pullRequest.getRepository();
+
+        List<GHWorkflowRun> ghWorkflowRuns = repository
+                .queryWorkflowRuns()
+                .branch(pullRequest.getHead().getRef())
+                .status(GHWorkflowRun.Status.COMPLETED)
+                .list().toList();
+
+        Map<String, Optional<GHWorkflowRun>> lastWorkflowRuns = ghWorkflowRuns.stream()
+                .filter(workflowRun -> WorkflowConstants.QUARKUS_CI_WORKFLOW_NAME.equals(workflowRun.getName())
+                        || WorkflowConstants.QUARKUS_DOCUMENTATION_CI_WORKFLOW_NAME.equals(workflowRun.getName()))
+                .filter(workflowRun -> workflowRun.getHeadRepository().getOwnerName()
+                        .equals(pullRequest.getHead().getRepository().getOwnerName()))
+                .collect(Collectors.groupingBy(GHWorkflowRun::getName,
+                        Collectors.maxBy(Comparator.comparing(GHWorkflowRun::getRunNumber))));
+
+        for (Map.Entry<String, Optional<GHWorkflowRun>> lastWorkflowRun : lastWorkflowRuns.entrySet()) {
+            if (lastWorkflowRun.getValue().isPresent()) {
+                if (!quarkusBotConfig.isDryRun()) {
+                    lastWorkflowRun.getValue().get().rerun();
+                    LOG.debug("Pull request #" + pullRequest.getNumber() + " - Restart workflow: "
+                            + lastWorkflowRun.getValue().get().getHtmlUrl());
+                } else {
+                    LOG.info("Pull request #" + pullRequest.getNumber() + " - Restart workflow " + lastWorkflowRun.getKey());
+                }
+            }
+        }
+        return ReactionContent.ROCKET;
+    }
+}

--- a/src/main/java/io/quarkus/bot/config/QuarkusBotConfig.java
+++ b/src/main/java/io/quarkus/bot/config/QuarkusBotConfig.java
@@ -9,11 +9,21 @@ public class QuarkusBotConfig {
 
     Optional<Boolean> dryRun;
 
+    Optional<String> accessToken;
+
     public void setDryRun(Optional<Boolean> dryRun) {
         this.dryRun = dryRun;
     }
 
     public boolean isDryRun() {
         return dryRun.isPresent() && dryRun.get();
+    }
+
+    public void setAccessToken(Optional<String> accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public Optional<String> getAccessToken() {
+        return accessToken;
     }
 }


### PR DESCRIPTION
This branch aims to add commands handling on pull request command. 

On a pull request comment, it :
* check this is a comment on a pull request
* the user that commented this is not `@quarkus-bot`
* validate the user is part the `quarkus-push` teams

Once it is ok, it looks for a `Command` bean that match the comment body. 

The `RerunWorkflowCommand` accepts `test` and `retest` allowing: 
* `@quarkus-bot test` command 
* `@quarkus-bot retest` command

Regarding the workflow, it looks for **Quarkus CI** `WorkflowRun`, take the last one, and `rerun` it. 

I created the PR in draft as I'm not able to get a working `rerun`, no error, is thrown by the API. When I log the url of the workflow that should be rerun, it is the correct one. This may come from my repo not providing enough permissions but I'm not able to find what's missing, maybe @gsmet you will have some hints? 
