### PR TITLE
Upgrade to Quarkus 2.0.0.Final and Quarkus GitHub App 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,14 +14,14 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.version>1.13.7.Final</quarkus.version>
+        <quarkus.version>2.0.0.Final</quarkus.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <version.formatter.plugin>2.15.0</version.formatter.plugin>
         <version.impsort.plugin>1.4.1</version.impsort.plugin>
 
-        <quarkus-github-app.version>1.0.9</quarkus-github-app.version>
+        <quarkus-github-app.version>1.1.1</quarkus-github-app.version>
         <glob.version>0.9.0</glob.version>
     </properties>
     <dependencyManagement>

--- a/src/main/java/io/quarkus/bot/AnalyzeWorkflowRunResults.java
+++ b/src/main/java/io/quarkus/bot/AnalyzeWorkflowRunResults.java
@@ -41,7 +41,6 @@ import io.quarkus.bot.workflow.report.WorkflowReport;
 import io.quarkus.bot.workflow.report.WorkflowReportJob;
 import io.quarkus.bot.workflow.report.WorkflowReportTestCase;
 
-@SuppressWarnings("deprecation")
 public class AnalyzeWorkflowRunResults {
 
     private static final Logger LOG = Logger.getLogger(AnalyzeWorkflowRunResults.class);
@@ -124,7 +123,7 @@ public class AnalyzeWorkflowRunResults {
 
         WorkflowReport workflowReport = workflowReportOptional.get();
 
-        Optional<GHCheckRun> checkRunOptional = createCheckRun(workflowRun, pullRequest, workflowReport);
+        Optional<GHCheckRun> checkRunOptional = createCheckRun(workflowRun, pullRequest, artifactsAvailable, workflowReport);
 
         String commentReport = workflowReportFormatter.getCommentReport(workflowReport,
                 artifactsAvailable,
@@ -169,14 +168,14 @@ public class AnalyzeWorkflowRunResults {
     }
 
     private Optional<GHCheckRun> createCheckRun(GHWorkflowRun workflowRun, GHPullRequest pullRequest,
-            WorkflowReport workflowReport) {
+            boolean artifactsAvailable, WorkflowReport workflowReport) {
         if (!workflowReport.hasTestFailures() || quarkusBotConfig.isDryRun()) {
             return Optional.empty();
         }
 
         try {
             String name = "Build summary for " + workflowRun.getHeadSha();
-            String summary = workflowReportFormatter.getCheckRunReportSummary(workflowReport, pullRequest);
+            String summary = workflowReportFormatter.getCheckRunReportSummary(workflowReport, pullRequest, artifactsAvailable);
             String checkRunReport = workflowReportFormatter.getCheckRunReport(workflowReport, true);
             if (checkRunReport.length() > GITHUB_FIELD_LENGTH_HARD_LIMIT) {
                 checkRunReport = workflowReportFormatter.getCheckRunReport(workflowReport, false);

--- a/src/main/java/io/quarkus/bot/SetAreaLabelColor.java
+++ b/src/main/java/io/quarkus/bot/SetAreaLabelColor.java
@@ -22,7 +22,6 @@ public class SetAreaLabelColor {
 
     private static final String AREA_LABEL_COLOR = "0366d6";
 
-    @SuppressWarnings("deprecation")
     void setAreaLabelColor(@Label.Created GHEventPayload.Label labelPayload) throws IOException {
         GHLabel label = labelPayload.getLabel();
 

--- a/src/main/java/io/quarkus/bot/workflow/WorkflowReportFormatter.java
+++ b/src/main/java/io/quarkus/bot/workflow/WorkflowReportFormatter.java
@@ -12,8 +12,8 @@ import io.quarkus.qute.TemplateInstance;
 @ApplicationScoped
 public class WorkflowReportFormatter {
 
-    public String getCheckRunReportSummary(WorkflowReport report, GHPullRequest pullRequest) {
-        return Templates.checkRunReportSummary(report, pullRequest).render();
+    public String getCheckRunReportSummary(WorkflowReport report, GHPullRequest pullRequest, boolean artifactsAvailable) {
+        return Templates.checkRunReportSummary(report, pullRequest, artifactsAvailable).render();
     }
 
     public String getCheckRunReport(WorkflowReport report, boolean includeStackTraces) {
@@ -28,7 +28,8 @@ public class WorkflowReportFormatter {
     @CheckedTemplate
     private static class Templates {
 
-        public static native TemplateInstance checkRunReportSummary(WorkflowReport report, GHPullRequest pullRequest);
+        public static native TemplateInstance checkRunReportSummary(WorkflowReport report, GHPullRequest pullRequest,
+                boolean artifactsAvailable);
 
         public static native TemplateInstance checkRunReport(WorkflowReport report, boolean includeStackTraces);
 


### PR DESCRIPTION
@yrodiere I have a strange error with this upgrade related to the mocking infrastructure:

> java.lang.AssertionError: The event handler threw an exception: Unable to create mock instance of type 'GitHub'
> 	at io.quarkus.bot.it.IssueOpenedTest.triage(IssueOpenedTest.java:28)
> Caused by: org.mockito.exceptions.base.MockitoException: Unable to create mock instance of type 'GitHub'
> Caused by: org.mockito.creation.instance.InstantiationException: 
>
> Unable to create instance of 'GitHub$MockitoMock$524993271'.
Please ensure that the target class has a constructor that matches these argument types: [java.lang.String, org.kohsuke.github.HttpConnector$$Lambda$1067/0x0000000800907440, org.kohsuke.github.RateLimitHandler$1, org.kohsuke.github.AbuseLimitHandler$1, null, org.kohsuke.github.authorization.AuthorizationProvider$AnonymousAuthorizationProvider].

I wonder if it could be due to the new test class loader introduced for continuous testing... I checked the GitHub API and I don't see any change related to this constructor.