### PR TITLE
Drop OkHttp constraint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,7 @@
         <version.formatter.plugin>2.17.0</version.formatter.plugin>
         <version.impsort.plugin>1.4.1</version.impsort.plugin>
 
-        <quarkus-github-app.version>1.3.0</quarkus-github-app.version>
-        <okhttp.version>4.9.2</okhttp.version>
+        <quarkus-github-app.version>1.4.0</quarkus-github-app.version>
         <glob.version>0.9.0</glob.version>
         <build-reporting-maven-extension.version>1.0.5</build-reporting-maven-extension.version>
     </properties>
@@ -63,11 +62,6 @@
             <groupId>com.hrakaroo</groupId>
             <artifactId>glob</artifactId>
             <version>${glob.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>${okhttp.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.surefire</groupId>


### PR DESCRIPTION
Quarkus GitHub App is now using the Java 11+ HTTP client.