### PR TITLE
Make Patterns.find() null safe

### DIFF
--- a/src/main/java/io/quarkus/bot/util/Patterns.java
+++ b/src/main/java/io/quarkus/bot/util/Patterns.java
@@ -5,6 +5,13 @@ import java.util.regex.Pattern;
 public class Patterns {
 
     public static boolean find(String pattern, String string) {
+        if (Strings.isBlank(pattern)) {
+            return false;
+        }
+        if (Strings.isBlank(string)) {
+            return false;
+        }
+
         return Pattern.compile(pattern, Pattern.DOTALL | Pattern.CASE_INSENSITIVE).matcher(string)
                 .find();
     }

--- a/src/main/java/io/quarkus/bot/util/Strings.java
+++ b/src/main/java/io/quarkus/bot/util/Strings.java
@@ -6,6 +6,10 @@ public class Strings {
         return string != null && !string.trim().isEmpty();
     }
 
+    public static boolean isBlank(String string) {
+        return string == null || string.trim().isEmpty();
+    }
+
     private Strings() {
     }
 }


### PR DESCRIPTION
The reason for this change is that the `body` of an issue or PR can be null if there's nothing in it.