### PR TITLE
Detect dependabot from the user name rather than the branch name

### DIFF
--- a/src/main/java/io/quarkus/bot/AffectKindToPullRequest.java
+++ b/src/main/java/io/quarkus/bot/AffectKindToPullRequest.java
@@ -32,13 +32,8 @@ class AffectKindToPullRequest {
             return;
         }
 
-        // this doesn't work, we get a NPE for it:
-        // Cannot invoke "org.kohsuke.github.GitHub.intern(org.kohsuke.github.GHUser)" because the return value of "org.kohsuke.github.GHIssue.root()" is null
-        //        if (pullRequest.getUser() == null || pullRequest.getUser().getLogin() == null
-        //                || !pullRequest.getUser().getLogin().startsWith(DEPENDABOT)) {
-        //            return;
-        //        }
-        if (!pullRequest.getHead().getRef().startsWith(DEPENDABOT + "/")) {
+        if (pullRequest.getUser() == null || pullRequest.getUser().getLogin() == null
+                || !pullRequest.getUser().getLogin().startsWith(DEPENDABOT)) {
             return;
         }
 


### PR DESCRIPTION
@gsmet Creating this as a draft. I attempted to reproduce https://github.com/quarkusio/quarkus-github-bot/pull/189/files#r799633677 but failed for some reason... Let's see what happens on CI.