### PR TITLE
Affect `triage/needs-rebase` on Pull Requests with merge conflicts

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -167,6 +167,11 @@ The bot will automatically remove these labels when they are outdated:
 
 The bot enforces a specific color for any label created that starts with `area/` so that all these labels are consistent.
 
+=== Include `triage/needs-rebase` on unmergeable pull-requests
+
+Pull requests may require a rebase when conflicts appear. The bot adds a `triage/needs-rebase` label on pull requests that cannot be merged and removes it when the pull request is in a mergeable state again.
+
+
 == Contributing
 
 To participate to the development of this GitHub App, create a playground project in your own org and

--- a/src/main/java/io/quarkus/bot/AffectNeedsRebaseToOpenedPullRequests.java
+++ b/src/main/java/io/quarkus/bot/AffectNeedsRebaseToOpenedPullRequests.java
@@ -1,0 +1,51 @@
+package io.quarkus.bot;
+
+import io.quarkiverse.githubapp.event.PullRequest;
+import io.quarkiverse.githubapp.event.Push;
+import io.quarkus.bot.util.Labels;
+import org.kohsuke.github.GHEventPayload;
+import org.kohsuke.github.GHIssueState;
+import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHRepository;
+
+import java.io.IOException;
+
+public class AffectNeedsRebaseToOpenedPullRequests {
+
+    /**
+     * Affect triage/needs-rebase label on pull request events
+     */
+    void triageNeedsRebaseOnPullRequest(
+            @PullRequest.Opened @PullRequest.Reopened @PullRequest.Synchronize GHEventPayload.PullRequest pullRequestPayload)
+            throws IOException {
+        affectNeedsRebaseLabel(pullRequestPayload.getPullRequest());
+    }
+
+    void triageNeedsRebaseOnRepositoryPush(@Push GHEventPayload.Push pushRequestPayload) throws IOException {
+        GHRepository repository = pushRequestPayload.getRepository();
+        String defaultBranch = repository.getDefaultBranch();
+        for (GHPullRequest pullRequest : repository.getPullRequests(GHIssueState.OPEN)) {
+            if (!defaultBranch.equals(pullRequest.getBase().getRef())) {
+                continue;
+            }
+            affectNeedsRebaseLabel(pullRequest);
+        }
+    }
+
+    private void affectNeedsRebaseLabel(GHPullRequest pullRequest) throws IOException {
+        Boolean mergeable = pullRequest.getMergeable();
+        boolean hasNeedsRebaseLabel = pullRequest.getLabels().stream()
+                .anyMatch(label -> Labels.TRIAGE_NEEDS_REBASE.equals(label.getName()));
+        if (mergeable != null) {
+            if (mergeable) {
+                if (hasNeedsRebaseLabel) {
+                    pullRequest.removeLabels(Labels.TRIAGE_NEEDS_REBASE);
+                }
+            } else {
+                if (!hasNeedsRebaseLabel) {
+                    pullRequest.addLabels(Labels.TRIAGE_NEEDS_REBASE);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/io/quarkus/bot/util/Labels.java
+++ b/src/main/java/io/quarkus/bot/util/Labels.java
@@ -14,6 +14,7 @@ public class Labels {
     public static final String AREA_PREFIX = "area/";
     public static final String AREA_INFRA = "area/infra";
     public static final String TRIAGE_INVALID = "triage/invalid";
+    public static final String TRIAGE_NEEDS_REBASE = "triage/needs-rebase";
     public static final String TRIAGE_NEEDS_TRIAGE = "triage/needs-triage";
     public static final String TRIAGE_WAITING_FOR_CI = "triage/waiting-for-ci";
     public static final String TRIAGE_QE = "triage/qe?";


### PR DESCRIPTION
This adds the `triage/needs-rebase` label (or removes it) on opened pull-requests, making it easier to find pull-requests that require a rebase to be merged