### PR TITLE
Avoid adding labels that are already there when triaging issues

### DIFF
--- a/src/main/java/io/quarkus/bot/TriageIssue.java
+++ b/src/main/java/io/quarkus/bot/TriageIssue.java
@@ -22,6 +22,7 @@ import io.quarkus.bot.util.GHIssues;
 import io.quarkus.bot.util.Labels;
 import io.quarkus.bot.util.Strings;
 import io.quarkus.bot.util.Triage;
+import org.kohsuke.github.GHLabel;
 
 class TriageIssue {
 
@@ -62,6 +63,9 @@ class TriageIssue {
                 }
             }
         }
+
+        // remove from the set the labels already present on the pull request
+        issue.getLabels().stream().map(GHLabel::getName).forEach(labels::remove);
 
         if (!labels.isEmpty()) {
             if (!quarkusBotConfig.isDryRun()) {

--- a/src/main/java/io/quarkus/bot/TriagePullRequest.java
+++ b/src/main/java/io/quarkus/bot/TriagePullRequest.java
@@ -12,6 +12,7 @@ import javax.inject.Inject;
 
 import org.jboss.logging.Logger;
 import org.kohsuke.github.GHEventPayload;
+import org.kohsuke.github.GHLabel;
 import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHPullRequestFileDetail;
 
@@ -79,7 +80,7 @@ class TriagePullRequest {
         }
 
         // remove from the set the labels already present on the pull request
-        labels.removeAll(pullRequest.getLabels().stream().map(l -> l.getName()).collect(Collectors.toList()));
+        pullRequest.getLabels().stream().map(GHLabel::getName).forEach(labels::remove);
 
         if (!labels.isEmpty()) {
             if (!quarkusBotConfig.isDryRun()) {


### PR DESCRIPTION
I don't know why we do this, but I think if we do it for pull requests, we should do it for issues too?