### PR TITLE
Only log about artifacts not downloaded if not cancelled

### DIFF
--- a/src/main/java/io/quarkus/bot/buildreporter/BuildReporterEventHandler.java
+++ b/src/main/java/io/quarkus/bot/buildreporter/BuildReporterEventHandler.java
@@ -108,8 +108,10 @@ public class BuildReporterEventHandler {
             artifacts = artifactsAreReady.getArtifacts();
             artifactsAvailable = true;
         } catch (ConditionTimeoutException e) {
-            LOG.warn("Workflow run #" + workflowRun.getId()
-                    + " - Unable to get the artifacts in a timely manner, ignoring them");
+            if (workflowRun.getConclusion() != Conclusion.CANCELLED) {
+                LOG.warn("Workflow run #" + workflowRun.getId()
+                        + " - Unable to get the artifacts in a timely manner, ignoring them");
+            }
             artifacts = Collections.emptyList();
             artifactsAvailable = false;
         }


### PR DESCRIPTION
If the build is cancelled, there's a good chance the artifacts won't be
around so let's not log a warning.