### PR TITLE
Add guard for null organisations

### DIFF
--- a/src/main/java/io/quarkus/bot/PushToProjects.java
+++ b/src/main/java/io/quarkus/bot/PushToProjects.java
@@ -53,6 +53,10 @@ public class PushToProjects {
             return;
         }
 
+        if (issuePayload.getOrganization() == null) {
+            return;
+        }
+
         doProjectPush("Issue #" + issuePayload.getIssue().getNumber() + ", label " + issuePayload.getLabel().getName(),
                 issuePayload.getOrganization().getLogin(), issuePayload.getIssue(),
                 issuePayload.getLabel(), issuePayload.getIssue().getNodeId(), true, quarkusBotConfigFile,
@@ -64,6 +68,10 @@ public class PushToProjects {
             GitHub gitHub,
             DynamicGraphQLClient gitHubGraphQLClient) throws IOException {
         if (!Feature.PUSH_TO_PROJECTS.isEnabled(quarkusBotConfigFile)) {
+            return;
+        }
+
+        if (pullRequestPayload.getOrganization() == null) {
             return;
         }
 


### PR DESCRIPTION
When setting this up locally against a playground repository, I had the following exception: 

```
Exception: java.lang.NullPointerException: Cannot invoke "org.kohsuke.github.GHOrganization.getLogin()" because the return value of "org.kohsuke.github.GHEventPayload$PullRequest.getOrganization()" is null
at io.quarkus.bot.PushToProjects.pullRequestLabeled(PushToProjects.java:78)
at io.quarkus.bot.PushToProjects_Multiplexer_Subclass.pullRequestLabeled$$superforward1(Unknown Source)
at io.quarkus.bot.PushToProjects_Multiplexer_Subclass$$function$$9.apply(Unknown Source)
at io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:53)
```

The docs at https://docs.github.com/en/developers/webhooks-and-events/events/github-event-types say, for organisation, "The organization that was chosen by the actor to perform action that triggers the event.
The property appears in the event object only if it is applicable."