### PR TITLE
Update config so that dry run is true in dev mode

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,9 +18,8 @@ quarkus.openshift.env.vars.QUARKUS_OPTS=-Dquarkus.http.host=0.0.0.0 -Xmx150m
 #quarkus.openshift.env.vars.QUARKUS_BOT_DRY_RUN=true
 quarkus.openshift.env.secrets=quarkus-bot
 
-%dev.quarkus-bot.dry-run=true
+%dev.quarkus-github-bot.dry-run=true
 
-%test.quarkus-bot.dry-run=false
 %test.quarkus.github-app.app-id=0
 %test.quarkus.github-app.private-key=-----BEGIN RSA PRIVATE KEY-----\
 MIIEogIBAAKCAQEA30YvyuZAd+kGDT0nm/XAa93CqsDvC/iYOc4KsKsfBQs1MWjH\


### PR DESCRIPTION
My first bot started commenting and tagging people, which I hadn't expected. Oops! It turns out it wasn't running in dry run mode, even in dev mode. 

It looks like the code expects 

```
@ConfigMapping(prefix = "quarkus-github-bot")
```

and the readme advises setting `_DEV_QUARKUS_GITHUB_BOT_DRY_RUN`, but the `application.properties` in the codebase uses `quarkus-bot`. I've updated the boilerplate config so dry run is enabled out of the box in dev mode.