### PR TITLE
Add expectations that pullrequest.listFiles() is called

### DIFF
--- a/src/test/java/io/quarkus/bot/it/PullRequestOpenedTest.java
+++ b/src/test/java/io/quarkus/bot/it/PullRequestOpenedTest.java
@@ -1,12 +1,7 @@
 package io.quarkus.bot.it;
 
-import static io.quarkiverse.githubapp.testing.GitHubAppTesting.given;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
-
-import java.io.IOException;
-
+import io.quarkiverse.githubapp.testing.GitHubAppTest;
+import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.kohsuke.github.GHEvent;
@@ -14,8 +9,13 @@ import org.kohsuke.github.GHPullRequestFileDetail;
 import org.kohsuke.github.PagedIterable;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import io.quarkiverse.githubapp.testing.GitHubAppTest;
-import io.quarkus.test.junit.QuarkusTest;
+import java.io.IOException;
+
+import static io.quarkiverse.githubapp.testing.GitHubAppTesting.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 @QuarkusTest
 @GitHubAppTest
@@ -215,6 +215,7 @@ public class PullRequestOpenedTest {
                 .then().github(mocks -> {
                     verify(mocks.pullRequest(527350930))
                             .addLabels("area/test1", "area/test2");
+                    verify(mocks.pullRequest(527350930), times(2)).listFiles();
                     verifyNoMoreInteractions(mocks.ghObjects());
                 });
     }
@@ -248,6 +249,7 @@ public class PullRequestOpenedTest {
                 .then().github(mocks -> {
                     verify(mocks.pullRequest(527350930))
                             .addLabels("area/test1", "area/test2");
+                    verify(mocks.pullRequest(527350930), times(2)).listFiles();
                     verifyNoMoreInteractions(mocks.ghObjects());
                 });
     }
@@ -282,6 +284,7 @@ public class PullRequestOpenedTest {
                 .then().github(mocks -> {
                     verify(mocks.pullRequest(527350930))
                             .addLabels("area/test1", "area/test2", "area/test3");
+                    verify(mocks.pullRequest(527350930), times(2)).listFiles();
                     verifyNoMoreInteractions(mocks.ghObjects());
                 });
     }
@@ -310,6 +313,7 @@ public class PullRequestOpenedTest {
                 .then().github(mocks -> {
                     verify(mocks.pullRequest(527350930))
                             .comment("This is an urgent PR");
+                    verify(mocks.pullRequest(527350930)).listFiles();
                     verifyNoMoreInteractions(mocks.ghObjects());
                 });
     }


### PR DESCRIPTION
I’m a little bit confused by what’s going on here, so would welcome some insight on why this fix is (apparently?) needed. 

When I run `mvn quarkus:dev`, I get 4 test failures, all in `PullRequestOpenedTest#triage*. I don’t see the failures with `mvn install test`.

```
No interactions wanted here:
-> at io.quarkus.bot.it.PullRequestOpenedTest.lambda$triageComment$23(PullRequestOpenedTest.java:313)
But found this interaction on mock 'GHPullRequest#527350930':
-> at io.quarkus.bot.util.Triage.matchRuleFromChangedFiles(Triage.java:89)
***
For your reference, here is the list of all invocations ([?] - means unverified).
1. -> at io.quarkus.bot.TriagePullRequest.triagePullRequest(TriagePullRequest.java:55)
2. [?]-> at io.quarkus.bot.util.Triage.matchRuleFromChangedFiles(Triage.java:89)
3. -> at io.quarkus.bot.TriagePullRequest.triagePullRequest(TriagePullRequest.java:78)
4. -> at io.quarkus.bot.TriagePullRequest.triagePullRequest(TriagePullRequest.java:94)

2022-08-12 16:28:44,122 ERROR [io.qua.test] (Test runner thread) >>>>>>>>>>>>>>>>>>>> 4 TESTS FAILED <<<<<<<<<<<<<<<<<<<<


--
4 tests failed (14 passing, 0 skipped), 18 tests were run in 3550ms. Tests completed at 16:28:44.
Press [r] to re-run, [o] Toggle test output, [:] for the terminal, [h] for more options>
```

Tracing through the code, I can see that the problem line is this one

```
verifyNoMoreInteractions(mocks.ghObjects());
```

`mocks.ghObjects[1]` is the pull request, and `Triage` calls `listFiles` on it, in both test modes. 
So I understand why the continuous testing is failing, but I don’t understand why the normal testing is passing. 

If I do the tactical fix of verifying the extra interaction, both test modes pass. 
That also confuses me - if Mockito knows the interaction has happened well enough for `verify` to pass,
why is `verifyNoMoreInteractions` passing? 

I’ve attached a pragmatic change with the fix, but I’d love to understand better the root cause of the difference.