### PR TITLE
Propagate buildNumber to Quarkus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,11 @@
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <version>${quarkus.version}</version>
+                <configuration>
+                    <systemProperties>
+                        <buildNumber>${buildNumber}</buildNumber>
+                    </systemProperties>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
This is necessary if we want to see the build number in the startup logs, i.e. this:

```
2022-09-26 13:53:40,388 INFO  [io.quarkus] (main) quarkus-bot f621887 on JVM (powered by Quarkus 2.12.2.Final) started in 0.837s. Listening on: http://0.0.0.0:8080
```

Instead of this:

```
2022-09-26 13:53:13,120 INFO  [io.quarkus] (main) quarkus-bot 999-SNAPSHOT on JVM (powered by Quarkus 2.12.2.Final) started in 0.935s. Listening on: http://0.0.0.0:8080
```