### PR TITLE
Don't add the need-triage label to extension proposals

### DIFF
--- a/src/main/java/io/quarkus/bot/TriageIssue.java
+++ b/src/main/java/io/quarkus/bot/TriageIssue.java
@@ -87,7 +87,8 @@ class TriageIssue {
             }
         }
 
-        if (mentions.isEmpty() && !Labels.hasAreaLabels(labels) && !GHIssues.hasAreaLabel(issue)) {
+        if (mentions.isEmpty() && !Labels.hasAreaLabels(labels) && !GHIssues.hasAreaLabel(issue)
+                && !GHIssues.hasLabel(issue, Labels.KIND_EXTENSION_PROPOSAL)) {
             if (!quarkusBotConfig.isDryRun()) {
                 issue.addLabels(Labels.TRIAGE_NEEDS_TRIAGE);
             } else {

--- a/src/main/java/io/quarkus/bot/util/Labels.java
+++ b/src/main/java/io/quarkus/bot/util/Labels.java
@@ -26,7 +26,9 @@ public class Labels {
     public static final String KIND_NEW_FEATURE = "kind/new-feature";
     public static final String KIND_COMPONENT_UPGRADE = "kind/component-upgrade";
     public static final String KIND_BUGFIX = "kind/bugfix";
-    public static final Set<String> KIND_LABELS = Set.of(KIND_BUG, KIND_ENHANCEMENT, KIND_NEW_FEATURE);
+
+    public static final String KIND_EXTENSION_PROPOSAL = "kind/extension-proposal";
+    public static final Set<String> KIND_LABELS = Set.of(KIND_BUG, KIND_ENHANCEMENT, KIND_NEW_FEATURE, KIND_EXTENSION_PROPOSAL);
 
     private Labels() {
     }


### PR DESCRIPTION
Because there's noto triage to be done, really: we generally can't add another label to those issues.

What's needed is just a "steward" to "own" these issues and decide whether the extensions are worth having a core contributor spend time on it, or guide someone wanting to contribute it.

But in any case, a triagers like me who spends a few minutes each day assigning the right label to issues generally won't be able to help here.

See also https://github.com/quarkusio/quarkus-github-lottery/issues/32