### PR TITLE
Use linked issues API to get linked issues

### DIFF
--- a/src/main/java/io/quarkus/bot/AffectKindToPullRequest.java
+++ b/src/main/java/io/quarkus/bot/AffectKindToPullRequest.java
@@ -18,6 +18,7 @@ import io.quarkus.bot.config.QuarkusGitHubBotConfigFile;
 import io.quarkus.bot.util.IssueExtractor;
 import io.quarkus.bot.util.Labels;
 import io.quarkus.bot.util.Strings;
+import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
 
 class AffectKindToPullRequest {
 
@@ -53,7 +54,8 @@ class AffectKindToPullRequest {
     }
 
     void fromIssues(@PullRequest.Closed GHEventPayload.PullRequest pullRequestPayload,
-            @ConfigFile("quarkus-github-bot.yml") QuarkusGitHubBotConfigFile quarkusBotConfigFile) throws IOException {
+            @ConfigFile("quarkus-github-bot.yml") QuarkusGitHubBotConfigFile quarkusBotConfigFile,
+            DynamicGraphQLClient gitHubGraphQLClient) throws IOException {
         if (!Feature.QUARKUS_REPOSITORY_WORKFLOW.isEnabled(quarkusBotConfigFile)) {
             return;
         }
@@ -65,7 +67,7 @@ class AffectKindToPullRequest {
         }
 
         IssueExtractor issueExtractor = new IssueExtractor(pullRequest.getRepository().getFullName());
-        Set<Integer> issueNumbers = issueExtractor.extractIssueNumbers(pullRequest.getBody());
+        Set<Integer> issueNumbers = issueExtractor.extractIssueNumbers(pullRequest, gitHubGraphQLClient);
 
         Set<String> labels = new HashSet<>();
         for (Integer issueNumber : issueNumbers) {

--- a/src/main/java/io/quarkus/bot/util/IssueExtractor.java
+++ b/src/main/java/io/quarkus/bot/util/IssueExtractor.java
@@ -1,9 +1,21 @@
 package io.quarkus.bot.util;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.ExecutionException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import javax.json.JsonObject;
+
+import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHRepository;
+
+import io.smallrye.graphql.client.Response;
+import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
 
 public class IssueExtractor {
 
@@ -24,5 +36,71 @@ public class IssueExtractor {
             result.add(issueNumber);
         }
         return result;
+    }
+
+    public Set<Integer> extractIssueNumbers(GHPullRequest pullRequest, DynamicGraphQLClient gitHubGraphQLClient) {
+        Set<Integer> result = new TreeSet<>();
+
+        String prBody = pullRequest.getBody();
+        result.addAll(extractFromPRContent(prBody));
+        result.addAll(extractWithGraphQLApi(pullRequest, gitHubGraphQLClient));
+        return result;
+    }
+
+    public Set<Integer> extractFromPRContent(String content) {
+        Set<Integer> result = new TreeSet<>();
+        Matcher matcher = pattern.matcher(content);
+        while (matcher.find()) {
+            Integer issueNumber = Integer.valueOf(matcher.group(1));
+            result.add(issueNumber);
+        }
+        return result;
+    }
+
+    public Set<Integer> extractWithGraphQLApi(GHPullRequest pullRequest, DynamicGraphQLClient gitHubGraphQLClient) {
+
+        GHRepository repository = pullRequest.getRepository();
+        try {
+            Map<String, Object> variables = new HashMap<>();
+            variables.put("owner", repository.getOwnerName());
+            variables.put("repoName", repository.getName());
+            variables.put("prNumber", pullRequest.getNumber());
+
+            Response response = gitHubGraphQLClient.executeSync("""
+                        query($owner: String! $repoName: String! $prNumber: Int!) {
+                            repository(owner: $owner, name: $repoName) {
+                              pullRequest(number: $prNumber) {
+                                closingIssuesReferences(first: 50) {
+                                  edges {
+                                    node {
+                                      number
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                    """, variables);
+
+            if (response.hasError()) {
+                throw new IllegalStateException(
+                        "Unable to get closingIssuesReferences for PR #" + pullRequest.getNumber() + " of repository "
+                                + repository.getFullName() + ": " + response.getErrors());
+            }
+
+            return response.getData().getJsonObject("repository")
+                    .getJsonObject("pullRequest")
+                    .getJsonObject("closingIssuesReferences")
+                    .getJsonArray("edges").stream()
+                    .map(JsonObject.class::cast)
+                    .map(obj -> obj.getJsonObject("node").getInt("number"))
+                    .collect(Collectors.toSet());
+
+        } catch (InterruptedException | ExecutionException e) {
+            throw new IllegalStateException(
+                    "Unable to get closingIssuesReferences for PR #" + pullRequest.getNumber() + " of repository "
+                            + repository.getFullName(),
+                    e);
+        }
     }
 }

--- a/src/main/java/io/quarkus/bot/util/IssueExtractor.java
+++ b/src/main/java/io/quarkus/bot/util/IssueExtractor.java
@@ -28,16 +28,6 @@ public class IssueExtractor {
                 Pattern.CASE_INSENSITIVE);
     }
 
-    public Set<Integer> extractIssueNumbers(String content) {
-        Set<Integer> result = new TreeSet<>();
-        Matcher matcher = pattern.matcher(content);
-        while (matcher.find()) {
-            Integer issueNumber = Integer.valueOf(matcher.group(1));
-            result.add(issueNumber);
-        }
-        return result;
-    }
-
     public Set<Integer> extractIssueNumbers(GHPullRequest pullRequest, DynamicGraphQLClient gitHubGraphQLClient) {
         Set<Integer> result = new TreeSet<>();
 


### PR DESCRIPTION
This pull request resolves #194. 

Linked issues of a pull request are extracted from its description, but also with Github GraphQL Api. 

The GraphQL request body is:
```
query($owner: String! $repoName: String! $prNumber: Int!) {
  repository(owner: $owner, name: $repoName) {
    pullRequest(number: $prNumber) {
      closingIssuesReferences(first: 50) {
        edges {
          node {
            number
          }
        }
      }
    }
  }
}
```

In `IssueExtractor` class, the results of these 2 metods are merged.