### PR TITLE
Maintainers are not cc to an issue or a pullRequest when they are already participants

### DIFF
--- a/src/main/java/io/quarkus/bot/NotifyQE.java
+++ b/src/main/java/io/quarkus/bot/NotifyQE.java
@@ -1,20 +1,25 @@
 package io.quarkus.bot;
 
-import io.quarkiverse.githubapp.ConfigFile;
-import io.quarkiverse.githubapp.event.Issue;
-import io.quarkiverse.githubapp.event.PullRequest;
-import io.quarkus.bot.config.Feature;
-import io.quarkus.bot.config.QuarkusGitHubBotConfig;
-import io.quarkus.bot.config.QuarkusGitHubBotConfigFile;
-import io.quarkus.bot.util.Labels;
+import java.io.IOException;
+
+import javax.inject.Inject;
+
 import org.jboss.logging.Logger;
 import org.kohsuke.github.GHEventPayload;
 import org.kohsuke.github.GHIssue;
 import org.kohsuke.github.GHLabel;
 import org.kohsuke.github.GHPullRequest;
 
-import javax.inject.Inject;
-import java.io.IOException;
+import io.quarkiverse.githubapp.ConfigFile;
+import io.quarkiverse.githubapp.event.Issue;
+import io.quarkiverse.githubapp.event.PullRequest;
+import io.quarkus.bot.config.Feature;
+import io.quarkus.bot.config.QuarkusGitHubBotConfig;
+import io.quarkus.bot.config.QuarkusGitHubBotConfigFile;
+import io.quarkus.bot.util.GHIssues;
+import io.quarkus.bot.util.Labels;
+import io.quarkus.bot.util.Mentions;
+import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
 
 public class NotifyQE {
 
@@ -24,40 +29,49 @@ public class NotifyQE {
     QuarkusGitHubBotConfig quarkusBotConfig;
 
     void commentOnIssue(@Issue.Labeled GHEventPayload.Issue issuePayload,
-            @ConfigFile("quarkus-github-bot.yml") QuarkusGitHubBotConfigFile quarkusBotConfigFile) throws IOException {
+            @ConfigFile("quarkus-github-bot.yml") QuarkusGitHubBotConfigFile quarkusBotConfigFile,
+            DynamicGraphQLClient gitHubGraphQLClient) throws IOException {
         if (!Feature.NOTIFY_QE.isEnabled(quarkusBotConfigFile)) {
             return;
         }
 
-        comment(quarkusBotConfigFile, issuePayload.getIssue(), issuePayload.getLabel());
+        comment(quarkusBotConfigFile, issuePayload.getIssue(), issuePayload.getLabel(), gitHubGraphQLClient);
     }
 
     void commentOnPullRequest(@PullRequest.Labeled GHEventPayload.PullRequest pullRequestPayload,
-            @ConfigFile("quarkus-github-bot.yml") QuarkusGitHubBotConfigFile quarkusBotConfigFile) throws IOException {
+            @ConfigFile("quarkus-github-bot.yml") QuarkusGitHubBotConfigFile quarkusBotConfigFile,
+            DynamicGraphQLClient gitHubGraphQLClient) throws IOException {
         if (!Feature.NOTIFY_QE.isEnabled(quarkusBotConfigFile)) {
             return;
         }
 
-        comment(quarkusBotConfigFile, pullRequestPayload.getPullRequest(), pullRequestPayload.getLabel());
+        comment(quarkusBotConfigFile, pullRequestPayload.getPullRequest(), pullRequestPayload.getLabel(), gitHubGraphQLClient);
     }
 
-    private void comment(QuarkusGitHubBotConfigFile quarkusBotConfigFile, GHIssue issue, GHLabel label) throws IOException {
+    private void comment(QuarkusGitHubBotConfigFile quarkusBotConfigFile, GHIssue issue, GHLabel label,
+            DynamicGraphQLClient gitHubGraphQLClient) throws IOException {
         if (quarkusBotConfigFile == null) {
             LOG.error("Unable to find triage configuration.");
             return;
         }
 
         if (label.getName().equals(Labels.TRIAGE_QE)) {
-            if (!quarkusBotConfig.isDryRun()) {
-                if (!quarkusBotConfigFile.triage.qe.notify.isEmpty()) {
-                    issue.comment("/cc @" + String.join(", @", quarkusBotConfigFile.triage.qe.notify));
+            if (!quarkusBotConfigFile.triage.qe.notify.isEmpty()) {
+                if (!quarkusBotConfig.isDryRun()) {
+                    Mentions mentions = new Mentions();
+                    mentions.add(quarkusBotConfigFile.triage.qe.notify, "qe");
+                    mentions.removeAlreadyParticipating(GHIssues.getParticipatingUsers(issue, gitHubGraphQLClient));
+
+                    if (!mentions.isEmpty()) {
+                        issue.comment("/cc " + mentions.getMentionsString());
+                    }
                 } else {
-                    LOG.warn("Added label: " + Labels.TRIAGE_QE + ", but no QE config is available");
+                    LOG.info((issue instanceof GHPullRequest ? "Pull Request #" : "Issue #") + issue.getNumber() +
+                            " - Added label: " + Labels.TRIAGE_QE +
+                            " - Mentioning QE: " + quarkusBotConfigFile.triage.qe.notify);
                 }
             } else {
-                LOG.info((issue instanceof GHPullRequest ? "Pull Request #" : "Issue #") + issue.getNumber() +
-                        " - Added label: " + Labels.TRIAGE_QE +
-                        " - Mentioning QE: " + quarkusBotConfigFile.triage.qe.notify);
+                LOG.warn("Added label: " + Labels.TRIAGE_QE + ", but no QE config is available");
             }
         }
     }

--- a/src/main/java/io/quarkus/bot/TriageIssue.java
+++ b/src/main/java/io/quarkus/bot/TriageIssue.java
@@ -23,6 +23,8 @@ import io.quarkus.bot.util.Labels;
 import io.quarkus.bot.util.Mentions;
 import io.quarkus.bot.util.Strings;
 import io.quarkus.bot.util.Triage;
+import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
+
 import org.kohsuke.github.GHLabel;
 
 class TriageIssue {
@@ -33,7 +35,8 @@ class TriageIssue {
     QuarkusGitHubBotConfig quarkusBotConfig;
 
     void triageIssue(@Issue.Opened GHEventPayload.Issue issuePayload,
-            @ConfigFile("quarkus-github-bot.yml") QuarkusGitHubBotConfigFile quarkusBotConfigFile) throws IOException {
+            @ConfigFile("quarkus-github-bot.yml") QuarkusGitHubBotConfigFile quarkusBotConfigFile,
+            DynamicGraphQLClient gitHubGraphQLClient) throws IOException {
         if (!Feature.TRIAGE_ISSUES_AND_PULL_REQUESTS.isEnabled(quarkusBotConfigFile)) {
             return;
         }
@@ -76,6 +79,7 @@ class TriageIssue {
             }
         }
 
+        mentions.removeAlreadyParticipating(GHIssues.getParticipatingUsers(issue, gitHubGraphQLClient));
         if (!mentions.isEmpty()) {
             comments.add("/cc " + mentions.getMentionsString());
         }

--- a/src/main/java/io/quarkus/bot/TriagePullRequest.java
+++ b/src/main/java/io/quarkus/bot/TriagePullRequest.java
@@ -20,9 +20,11 @@ import io.quarkus.bot.config.Feature;
 import io.quarkus.bot.config.QuarkusGitHubBotConfig;
 import io.quarkus.bot.config.QuarkusGitHubBotConfigFile;
 import io.quarkus.bot.config.QuarkusGitHubBotConfigFile.TriageRule;
+import io.quarkus.bot.util.GHIssues;
 import io.quarkus.bot.util.Mentions;
 import io.quarkus.bot.util.Strings;
 import io.quarkus.bot.util.Triage;
+import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
 
 class TriagePullRequest {
 
@@ -40,7 +42,8 @@ class TriagePullRequest {
 
     void triagePullRequest(
             @PullRequest.Opened @PullRequest.Edited @PullRequest.Synchronize GHEventPayload.PullRequest pullRequestPayload,
-            @ConfigFile("quarkus-github-bot.yml") QuarkusGitHubBotConfigFile quarkusBotConfigFile) throws IOException {
+            @ConfigFile("quarkus-github-bot.yml") QuarkusGitHubBotConfigFile quarkusBotConfigFile,
+            DynamicGraphQLClient gitHubGraphQLClient) throws IOException {
         if (!Feature.TRIAGE_ISSUES_AND_PULL_REQUESTS.isEnabled(quarkusBotConfigFile)) {
             return;
         }
@@ -86,6 +89,7 @@ class TriagePullRequest {
             }
         }
 
+        mentions.removeAlreadyParticipating(GHIssues.getParticipatingUsers(pullRequest, gitHubGraphQLClient));
         if (!mentions.isEmpty()) {
             comments.add("/cc " + mentions.getMentionsString());
         }

--- a/src/main/java/io/quarkus/bot/util/GHIssues.java
+++ b/src/main/java/io/quarkus/bot/util/GHIssues.java
@@ -1,11 +1,30 @@
 package io.quarkus.bot.util;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+import javax.json.JsonObject;
 
 import org.kohsuke.github.GHIssue;
 import org.kohsuke.github.GHLabel;
+import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHRepository;
+
+import io.smallrye.graphql.client.Response;
+import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
 
 public final class GHIssues {
+
+    public static final String QUERY_PARTICIPANT_ERROR = "Unable to get participants for %s #%s of repository %s";
+
+    public static final String ISSUE_TYPE = "issue";
+
+    public static final String PULL_REQUEST_TYPE = "pullRequest";
 
     public static boolean hasLabel(GHIssue issue, String labelName) throws IOException {
         for (GHLabel label : issue.getLabels()) {
@@ -23,6 +42,59 @@ public final class GHIssues {
             }
         }
         return false;
+    }
+
+    public static Set<String> getParticipatingUsers(GHIssue issue, DynamicGraphQLClient gitHubGraphQLClient) {
+        GHRepository repository = issue.getRepository();
+
+        String objectType = (issue instanceof GHPullRequest) ? PULL_REQUEST_TYPE : ISSUE_TYPE;
+
+        try {
+            Map<String, Object> variables = new HashMap<>();
+            variables.put("owner", repository.getOwnerName());
+            variables.put("repoName", repository.getName());
+            variables.put("number", issue.getNumber());
+
+            String graphqlRequest = """
+                        query($owner: String! $repoName: String! $prNumber: Int!) {
+                            repository(owner: $owner, name: $repoName) {
+                              $objectType(number: $number) {
+                                participants(first: 50) {
+                                  edges {
+                                    node {
+                                      login
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                    """.replace("$objectType", objectType);
+
+            Response response = gitHubGraphQLClient.executeSync(graphqlRequest, variables);
+
+            if (response == null) {
+                // typically in tests where we don't mock the GraphQL client
+                return Collections.emptySet();
+            }
+
+            if (response.hasError()) {
+                String errorMsg = String.format(QUERY_PARTICIPANT_ERROR, objectType, issue.getNumber(),
+                        repository.getFullName());
+                throw new IllegalStateException(errorMsg + " : " + response.getErrors());
+            }
+
+            return response.getData().getJsonObject("repository")
+                    .getJsonObject(objectType)
+                    .getJsonObject("participants")
+                    .getJsonArray("edges").stream()
+                    .map(JsonObject.class::cast)
+                    .map(obj -> obj.getJsonObject("node").getString("login"))
+                    .collect(Collectors.toSet());
+        } catch (InterruptedException | ExecutionException e) {
+            throw new IllegalStateException(
+                    String.format(QUERY_PARTICIPANT_ERROR, objectType, issue.getNumber(), repository.getFullName()), e);
+        }
     }
 
     private GHIssues() {

--- a/src/main/java/io/quarkus/bot/util/Mentions.java
+++ b/src/main/java/io/quarkus/bot/util/Mentions.java
@@ -1,5 +1,6 @@
 package io.quarkus.bot.util;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -24,6 +25,16 @@ public class Mentions {
         mentions.put(mention, reasons);
     }
 
+    public void add(Collection<String> mentions, String reason) {
+        for (String mention : mentions) {
+            add(mention, reason);
+        }
+    }
+
+    public void removeAlreadyParticipating(Collection<String> usersAlreadyParticipating) {
+        mentions.keySet().removeAll(usersAlreadyParticipating);
+    }
+
     public boolean isEmpty() {
         return mentions.isEmpty();
     }
@@ -33,13 +44,17 @@ public class Mentions {
      * @return string of form "@mention1, @mention2(reason1,reason2), @mention3(reason1)"
      */
     public String getMentionsString() {
-        return mentions.keySet().stream()
-                .map(key -> {
-                    Set<String> reasons = mentions.get(key);
+        if (mentions.isEmpty()) {
+            return null;
+        }
+
+        return mentions.entrySet().stream()
+                .map(es -> {
+                    Set<String> reasons = es.getValue();
                     if (reasons.isEmpty()) {
-                        return "@" + key;
+                        return "@" + es.getKey();
                     } else {
-                        return "@" + key + reasons.stream().collect(Collectors.joining(",", "(", ")"));
+                        return "@" + es.getKey() + reasons.stream().collect(Collectors.joining(",", "(", ")"));
                     }
                 })
                 .collect(Collectors.joining(", "));

--- a/src/test/java/io/quarkus/bot/it/util/GHIssuesTest.java
+++ b/src/test/java/io/quarkus/bot/it/util/GHIssuesTest.java
@@ -1,0 +1,159 @@
+package io.quarkus.bot.it.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.StringReader;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Stream;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.kohsuke.github.GHIssue;
+import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHRepository;
+import org.mockito.Mockito;
+
+import io.quarkus.bot.util.GHIssues;
+import io.quarkus.bot.util.Mentions;
+import io.smallrye.graphql.client.Response;
+import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
+
+public class GHIssuesTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = { GHIssues.ISSUE_TYPE, GHIssues.PULL_REQUEST_TYPE })
+    public void usersListIsFilteredWithGraphqlApiResult(String ghObjectType) throws ExecutionException, InterruptedException {
+
+        DynamicGraphQLClient mockDynamicGraphQLClient = Mockito.mock(DynamicGraphQLClient.class);
+
+        GHIssue mockGhObject = prepareGHIssueMock(ghObjectType);
+
+        Response mockResponse = Mockito.mock(Response.class);
+        when(mockResponse.getData()).thenReturn(buildMockJsonData(ghObjectType));
+        when(mockResponse.hasError()).thenReturn(false);
+        when(mockDynamicGraphQLClient.executeSync(anyString(), anyMap())).thenReturn(mockResponse);
+
+        Mentions mentions = new Mentions();
+        mentions.add(List.of("testUser1", "testUser2"), null);
+        mentions.removeAlreadyParticipating(GHIssues.getParticipatingUsers(mockGhObject, mockDynamicGraphQLClient));
+
+        verify(mockDynamicGraphQLClient, times(1)).executeSync(anyString(), anyMap());
+        assertThat(mentions.getMentionsString()).isEqualTo("@testUser2");
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideExceptionTestData")
+    public void exceptionIsThrownWhenGraphqlApiResponseHasError(String ghObjectType, String expectedErrorMesage)
+            throws ExecutionException, InterruptedException {
+
+        DynamicGraphQLClient mockDynamicGraphQLClient = Mockito.mock(DynamicGraphQLClient.class);
+
+        GHIssue mockGhObject = prepareGHIssueMock(ghObjectType);
+
+        Response mockResponse = Mockito.mock(Response.class);
+        when(mockResponse.hasError()).thenReturn(true);
+        when(mockDynamicGraphQLClient.executeSync(anyString(), anyMap())).thenReturn(mockResponse);
+
+        Exception exception = assertThrows(IllegalStateException.class,
+                () -> GHIssues.getParticipatingUsers(mockGhObject, mockDynamicGraphQLClient));
+        assertThat(exception.getMessage().contains(expectedErrorMesage));
+
+        verify(mockDynamicGraphQLClient, times(1)).executeSync(anyString(), anyMap());
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideExceptionTestData")
+    public void exceptionIsThrownWhenGraphqlApiThrowsException(String ghObjectType, String expectedErrorMesage)
+            throws ExecutionException, InterruptedException {
+
+        DynamicGraphQLClient mockDynamicGraphQLClient = Mockito.mock(DynamicGraphQLClient.class);
+
+        GHIssue mockGhObject = prepareGHIssueMock(ghObjectType);
+
+        when(mockDynamicGraphQLClient.executeSync(anyString(), anyMap())).thenThrow(ExecutionException.class);
+
+        Exception exception = assertThrows(IllegalStateException.class,
+                () -> GHIssues.getParticipatingUsers(mockGhObject, mockDynamicGraphQLClient));
+        assertThat(exception.getMessage().contains(expectedErrorMesage));
+
+        verify(mockDynamicGraphQLClient, times(1)).executeSync(anyString(), anyMap());
+    }
+
+    private static Stream<Arguments> provideExceptionTestData() {
+
+        String issueErrorMessage = String.format(GHIssues.QUERY_PARTICIPANT_ERROR, GHIssues.ISSUE_TYPE, TEST_ISSUE_NUMBER,
+                TEST_OWNER_NAME + ":" + TEST_REPO_NAME);
+        String pullRequestErrorMessage = String.format(GHIssues.QUERY_PARTICIPANT_ERROR, GHIssues.PULL_REQUEST_TYPE,
+                TEST_ISSUE_NUMBER,
+                TEST_OWNER_NAME + ":" + TEST_REPO_NAME);
+
+        return Stream.of(
+                Arguments.of(GHIssues.ISSUE_TYPE, issueErrorMessage),
+                Arguments.of(GHIssues.PULL_REQUEST_TYPE, pullRequestErrorMessage));
+    }
+
+    private final static String TEST_OWNER_NAME = "testOwnerName";
+
+    private final static String TEST_REPO_NAME = "testOwnerName";
+
+    private final static Integer TEST_ISSUE_NUMBER = 123456;
+
+    private GHIssue prepareGHIssueMock(String ghObjectType) {
+
+        GHIssue mockGhObject = null;
+        if (GHIssues.ISSUE_TYPE.equals(ghObjectType)) {
+            mockGhObject = Mockito.mock(GHIssue.class);
+        } else if (GHIssues.PULL_REQUEST_TYPE.equals(ghObjectType)) {
+            mockGhObject = Mockito.mock(GHPullRequest.class);
+        } else {
+            throw new IllegalArgumentException("Input type must be either issue or pullRequest");
+        }
+
+        GHRepository mockGHRepository = Mockito.mock(GHRepository.class);
+        when(mockGHRepository.getOwnerName()).thenReturn(TEST_OWNER_NAME);
+        when(mockGHRepository.getName()).thenReturn(TEST_REPO_NAME);
+        when(mockGHRepository.getFullName()).thenReturn(TEST_OWNER_NAME + ":" + TEST_REPO_NAME);
+
+        when(mockGhObject.getRepository()).thenReturn(mockGHRepository);
+        when(mockGhObject.getNumber()).thenReturn(TEST_ISSUE_NUMBER);
+
+        return mockGhObject;
+    }
+
+    private JsonObject buildMockJsonData(String ghObjectType) {
+
+        String mockJsonStr = """
+                  {
+                    "repository": {
+                      "$ghObjectType": {
+                        "participants": {
+                          "edges": [
+                            {
+                              "node": {
+                                "login": "testUser1"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                }
+                  """.replace("$ghObjectType", ghObjectType);
+
+        JsonReader jsonReader = Json.createReader(new StringReader(mockJsonStr));
+        return jsonReader.readObject();
+    }
+}


### PR DESCRIPTION
This pull request resolves #143.

Before cc maintainers to an issue or a pull request, participants of it are queried with Github GraphQL Api and are removed of list of maintainers that are notified.

The GraphQL request body is:
```
query($owner: String! $repoName: String! $prNumber: Int!) {
  repository(owner: $owner, name: $repoName) {
    $objectType(number: $number) {
      participants(first: 50) {
        edges {
          node {
            login
          }
        }
      }
    }
  }
}
```
where `$objectType` is replaced by `issue` or `pullRequest` according to the situation.