### PR TITLE
Upgrade build-reporter to 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
         <quarkus-github-app.version>2.0.1</quarkus-github-app.version>
         <glob.version>0.9.0</glob.version>
-        <build-reporter.version>3.0.0</build-reporter.version>
+        <build-reporter.version>3.1.0</build-reporter.version>
         <assertj.version>3.24.2</assertj.version>
     </properties>
     <dependencyManagement>


### PR DESCRIPTION
This restores the compatibility with the new version of Surefire