### PR TITLE
Enforce the job order

### DIFF
--- a/src/main/java/io/quarkus/bot/AnalyzeWorkflowRunResults.java
+++ b/src/main/java/io/quarkus/bot/AnalyzeWorkflowRunResults.java
@@ -16,7 +16,6 @@ import io.quarkus.bot.buildreporter.githubactions.BuildReporterEventHandler;
 import io.quarkus.bot.config.Feature;
 import io.quarkus.bot.config.QuarkusGitHubBotConfig;
 import io.quarkus.bot.config.QuarkusGitHubBotConfigFile;
-import io.quarkus.bot.workflow.QuarkusWorkflowConstants;
 import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
 
 public class AnalyzeWorkflowRunResults {
@@ -51,16 +50,67 @@ public class AnalyzeWorkflowRunResults {
 
         @Override
         public int compare(GHWorkflowJob o1, GHWorkflowJob o2) {
-            if (o1.getName().startsWith(QuarkusWorkflowConstants.JOB_NAME_INITIAL_JDK_PREFIX)
-                    && !o2.getName().startsWith(QuarkusWorkflowConstants.JOB_NAME_INITIAL_JDK_PREFIX)) {
-                return -1;
-            }
-            if (!o1.getName().startsWith(QuarkusWorkflowConstants.JOB_NAME_INITIAL_JDK_PREFIX)
-                    && o2.getName().startsWith(QuarkusWorkflowConstants.JOB_NAME_INITIAL_JDK_PREFIX)) {
-                return 1;
+            int order1 = getOrder(o1.getName());
+            int order2 = getOrder(o2.getName());
+
+            if (order1 == order2) {
+                return o1.getName().compareToIgnoreCase(o2.getName());
             }
 
-            return o1.getName().compareTo(o2.getName());
+            return order1 - order2;
+        }
+
+        private static int getOrder(String jobName) {
+            if (jobName.startsWith("Initial JDK")) {
+                return 1;
+            }
+            if (jobName.startsWith("Calculate Test Jobs")) {
+                return 2;
+            }
+            if (jobName.startsWith("JVM Tests - ")) {
+                if (jobName.contains("Windows")) {
+                    return 12;
+                }
+                return 11;
+            }
+            if (jobName.startsWith("Maven Tests - ")) {
+                if (jobName.contains("Windows")) {
+                    return 22;
+                }
+                return 21;
+            }
+            if (jobName.startsWith("Gradle Tests - ")) {
+                if (jobName.contains("Windows")) {
+                    return 32;
+                }
+                return 31;
+            }
+            if (jobName.startsWith("Devtools Tests - ")) {
+                if (jobName.contains("Windows")) {
+                    return 42;
+                }
+                return 41;
+            }
+            if (jobName.startsWith("Kubernetes Tests - ")) {
+                if (jobName.contains("Windows")) {
+                    return 52;
+                }
+                return 51;
+            }
+            if (jobName.startsWith("Quickstarts Compilation")) {
+                return 61;
+            }
+            if (jobName.startsWith("MicroProfile TCKs Tests")) {
+                return 71;
+            }
+            if (jobName.startsWith("Native Tests - ")) {
+                if (jobName.contains("Windows")) {
+                    return 82;
+                }
+                return 81;
+            }
+
+            return 200;
         }
     }
 }


### PR DESCRIPTION
Sometimes, GitHub pushes the jobs in a different order so let's make sure they are properly ordered.