### PR TITLE
Post comment advising squash merge if merge commits are found

### DIFF
--- a/src/main/java/io/quarkus/bot/CheckPullRequestContributionRules.java
+++ b/src/main/java/io/quarkus/bot/CheckPullRequestContributionRules.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 import jakarta.inject.Inject;
 
@@ -17,6 +18,7 @@ import org.kohsuke.github.GHCheckRunBuilder.Annotation;
 import org.kohsuke.github.GHCheckRunBuilder.Output;
 import org.kohsuke.github.GHCommit;
 import org.kohsuke.github.GHEventPayload;
+import org.kohsuke.github.GHIssueComment;
 import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHPullRequestCommitDetail;
 import org.kohsuke.github.GHRepository;
@@ -26,6 +28,8 @@ import io.quarkiverse.githubapp.event.PullRequest;
 import io.quarkus.bot.config.Feature;
 import io.quarkus.bot.config.QuarkusGitHubBotConfig;
 import io.quarkus.bot.config.QuarkusGitHubBotConfigFile;
+import io.quarkus.bot.service.GHIssueCommentService;
+import io.quarkus.bot.util.Strings;
 
 public class CheckPullRequestContributionRules {
 
@@ -36,6 +40,12 @@ public class CheckPullRequestContributionRules {
     public static final String MERGE_COMMIT_CHECK_RUN_NAME = "Check Pull Request - Merge commits";
     public static final String MERGE_COMMIT_ERROR_OUTPUT_TITLE = "PR contains merge commits";
     public static final String MERGE_COMMIT_ERROR_OUTPUT_SUMMARY = "Pull request that contains merge commits can not be merged";
+    public static final String MERGE_COMMIT_COMMENT_MESSAGE = """
+            \u26a0\ufe0f **This pull request contains merge commits.**
+
+            This is acceptable provided that it is **squash merged**.
+
+            Maintainers: please use the **Squash and merge** option when merging this pull request.""";
 
     public static final String FIXUP_COMMIT_CHECK_RUN_NAME = "Check Pull Request - Fixup commits";
     public static final String FIXUP_COMMIT_ERROR_OUTPUT_TITLE = "PR contains fixup commits";
@@ -46,6 +56,9 @@ public class CheckPullRequestContributionRules {
 
     @Inject
     QuarkusGitHubBotConfig quarkusBotConfig;
+
+    @Inject
+    GHIssueCommentService commentService;
 
     void checkPullRequestContributionRules(
             @PullRequest.Opened @PullRequest.Reopened @PullRequest.Synchronize GHEventPayload.PullRequest pullRequestPayload,
@@ -66,6 +79,9 @@ public class CheckPullRequestContributionRules {
             // Merge commits
             buildCheckRun(checkCommitData.getMergeCommitDetails(), repostitory, headCommit,
                     MERGE_COMMIT_CHECK_RUN_NAME, MERGE_COMMIT_ERROR_OUTPUT_TITLE, MERGE_COMMIT_ERROR_OUTPUT_SUMMARY);
+
+            // Post comment advising squash merge if merge commits are found
+            handleMergeCommitComment(pullRequest, checkCommitData.getMergeCommitDetails());
 
             // Fixup commits
             buildCheckRun(checkCommitData.getFixupCommitDetails(), repostitory, headCommit,
@@ -161,6 +177,23 @@ public class CheckPullRequestContributionRules {
                     .withConclusion(Conclusion.FAILURE);
             check.add(output);
             check.create();
+        }
+    }
+
+    private void handleMergeCommitComment(GHPullRequest pullRequest,
+            List<GHPullRequestCommitDetail> mergeCommitDetails) throws IOException {
+        Optional<GHIssueComment> existingComment = commentService.findBotCommentInIssue(
+                pullRequest, Strings.MERGE_COMMIT_COMMENT_MARKER);
+
+        if (!mergeCommitDetails.isEmpty()) {
+            if (existingComment.isEmpty()) {
+                String formattedComment = Strings.commentByBot(MERGE_COMMIT_COMMENT_MESSAGE)
+                        + Strings.MERGE_COMMIT_COMMENT_MARKER;
+                pullRequest.comment(formattedComment);
+            }
+        } else {
+            existingComment.ifPresent(comment -> commentService.deleteComment(
+                    comment, pullRequest.getNumber(), false));
         }
     }
 

--- a/src/main/java/io/quarkus/bot/util/Strings.java
+++ b/src/main/java/io/quarkus/bot/util/Strings.java
@@ -2,6 +2,7 @@ package io.quarkus.bot.util;
 
 public class Strings {
     public static final String EDITORIAL_RULES_COMMENT_MARKER = "\n<!-- Quarkus-Bot-Editor-Rules -->";
+    public static final String MERGE_COMMIT_COMMENT_MARKER = "\n<!-- Quarkus-Bot-Merge-Commits -->";
 
     public static boolean isNotBlank(String string) {
         return string != null && !string.trim().isEmpty();

--- a/src/test/java/io/quarkus/bot/it/CheckPullRequestContributionRulesTest.java
+++ b/src/test/java/io/quarkus/bot/it/CheckPullRequestContributionRulesTest.java
@@ -2,6 +2,7 @@ package io.quarkus.bot.it;
 
 import static io.quarkiverse.githubapp.testing.GitHubAppTesting.given;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -10,6 +11,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,6 +21,7 @@ import org.kohsuke.github.GHCheckRunBuilder.Output;
 import org.kohsuke.github.GHCommit;
 import org.kohsuke.github.GHCommitPointer;
 import org.kohsuke.github.GHEvent;
+import org.kohsuke.github.GHIssueComment;
 import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHPullRequestCommitDetail;
 import org.kohsuke.github.GHRepository;
@@ -80,6 +83,7 @@ public class CheckPullRequestContributionRulesTest {
 
             mockPR = mocks.pullRequest(samplePullRequestId);
             when(mockPR.getRepository()).thenReturn(mockRepo);
+            when(mockPR.getComments()).thenReturn(List.of());
 
             setupMockHeadCommit();
 
@@ -101,6 +105,8 @@ public class CheckPullRequestContributionRulesTest {
                     verify(mockCheckRunBuilder, times(2)).withConclusion(eq(GHCheckRun.Conclusion.SUCCESS));
                     verify(mockCheckRunBuilder, times(2)).create();
 
+                    verify(mockPR, times(1)).getComments();
+
                     verifyNoMoreInteractions(mocks.ghObjects());
                 });
     }
@@ -119,6 +125,7 @@ public class CheckPullRequestContributionRulesTest {
 
             mockPR = mocks.pullRequest(samplePullRequestId);
             when(mockPR.getRepository()).thenReturn(mockRepo);
+            when(mockPR.getComments()).thenReturn(List.of());
 
             setupMockHeadCommit();
 
@@ -143,8 +150,39 @@ public class CheckPullRequestContributionRulesTest {
                     verify(mockCheckRunBuilder, times(1)).add(any(Output.class));
                     verify(mockCheckRunBuilder, times(2)).create();
 
+                    verify(mockPR, times(1)).getComments();
+                    verify(mockPR, times(1)).comment(contains("squash merged"));
+
                     verifyNoMoreInteractions(mocks.ghObjects());
                 });
+    }
+
+    /**
+     * If PR contains merge commits and no existing bot comment,
+     * a comment advising squash merge is posted.
+     */
+    @Test
+    void pullRequestWithMergeCommitPostsSquashMergeComment() throws IOException {
+
+        setupMock();
+
+        given().github(mocks -> {
+            mocks.configFile("quarkus-github-bot.yml").fromString("features: [ CHECK_CONTRIBUTION_RULES ]\n");
+
+            mockPR = mocks.pullRequest(samplePullRequestId);
+            when(mockPR.getRepository()).thenReturn(mockRepo);
+            when(mockPR.getComments()).thenReturn(List.of());
+
+            setupMockHeadCommit();
+
+            GHPullRequestCommitDetail mockMergeCommitDetail = setupMockMergeCommit();
+            PagedIterable<GHPullRequestCommitDetail> iterableMock = MockHelper.mockPagedIterable(mockMergeCommitDetail);
+            when(mockPR.listCommits()).thenReturn(iterableMock);
+        })
+                .when().payloadFromString(getSamplePullRequestPayload())
+                .event(GHEvent.PULL_REQUEST)
+                .then().github(mocks -> verify(mockPR, times(1))
+                        .comment(contains("squash merged")));
     }
 
     /**
@@ -161,6 +199,7 @@ public class CheckPullRequestContributionRulesTest {
 
             mockPR = mocks.pullRequest(samplePullRequestId);
             when(mockPR.getRepository()).thenReturn(mockRepo);
+            when(mockPR.getComments()).thenReturn(List.of());
 
             setupMockHeadCommit();
 
@@ -185,8 +224,73 @@ public class CheckPullRequestContributionRulesTest {
                     verify(mockCheckRunBuilder, times(1)).add(any(Output.class));
                     verify(mockCheckRunBuilder, times(2)).create();
 
+                    verify(mockPR, times(1)).getComments();
+
                     verifyNoMoreInteractions(mocks.ghObjects());
                 });
+    }
+
+    /**
+     * If PR no longer contains merge commits but a bot comment exists,
+     * the comment is deleted.
+     */
+    @Test
+    void pullRequestWithoutMergeCommitDeletesExistingComment() throws IOException {
+
+        setupMock();
+
+        GHIssueComment mockComment = mock(GHIssueComment.class);
+        when(mockComment.getBody()).thenReturn(
+                "old comment" + io.quarkus.bot.util.Strings.MERGE_COMMIT_COMMENT_MARKER);
+
+        given().github(mocks -> {
+            mocks.configFile("quarkus-github-bot.yml").fromString("features: [ CHECK_CONTRIBUTION_RULES ]\n");
+
+            mockPR = mocks.pullRequest(samplePullRequestId);
+            when(mockPR.getRepository()).thenReturn(mockRepo);
+            when(mockPR.getComments()).thenReturn(List.of(mockComment));
+
+            setupMockHeadCommit();
+
+            PagedIterable<GHPullRequestCommitDetail> iterableMock = MockHelper.mockPagedIterable();
+            when(mockPR.listCommits()).thenReturn(iterableMock);
+        })
+                .when().payloadFromString(getSamplePullRequestPayload())
+                .event(GHEvent.PULL_REQUEST)
+                .then().github(mocks -> verify(mockComment, times(1))
+                        .delete());
+    }
+
+    /**
+     * If PR contains merge commits and a bot comment already exists,
+     * no new comment is posted (idempotent).
+     */
+    @Test
+    void pullRequestWithMergeCommitDoesNotDuplicateComment() throws IOException {
+
+        setupMock();
+
+        GHIssueComment mockComment = mock(GHIssueComment.class);
+        when(mockComment.getBody()).thenReturn(
+                "existing comment" + io.quarkus.bot.util.Strings.MERGE_COMMIT_COMMENT_MARKER);
+
+        given().github(mocks -> {
+            mocks.configFile("quarkus-github-bot.yml").fromString("features: [ CHECK_CONTRIBUTION_RULES ]\n");
+
+            mockPR = mocks.pullRequest(samplePullRequestId);
+            when(mockPR.getRepository()).thenReturn(mockRepo);
+            when(mockPR.getComments()).thenReturn(List.of(mockComment));
+
+            setupMockHeadCommit();
+
+            GHPullRequestCommitDetail mockMergeCommitDetail = setupMockMergeCommit();
+            PagedIterable<GHPullRequestCommitDetail> iterableMock = MockHelper.mockPagedIterable(mockMergeCommitDetail);
+            when(mockPR.listCommits()).thenReturn(iterableMock);
+        })
+                .when().payloadFromString(getSamplePullRequestPayload())
+                .event(GHEvent.PULL_REQUEST)
+                .then().github(mocks -> verify(mockPR, times(0))
+                        .comment(any(String.class)));
     }
 
     private static long samplePullRequestId = 1091703530;


### PR DESCRIPTION
This still reports a failing check when a PR branch contains merge commits, but it reminds maintainers about the possibility to use a squashed commit merge if the repository and branch protection rules allow it.